### PR TITLE
Fix plot missing time info #16

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: DiveR
 Type: Package
 Title: Simulation Tool for Scuba Diving and Gas Desaturation
-Version: 0.4.0
+Version: 0.4.1
 Author: Maxime Jaunatre 
 Maintainer: Maxime Jaunatre <maxime.jaunatre@yahoo.fr>
 Description: Package for scubadiving planification.

--- a/R/graphic.R
+++ b/R/graphic.R
@@ -64,6 +64,7 @@ plot.dive <- function(x,
   if (!add) {x$dtcurve$times <- x$dtcurve$times + x$hour[1]}
   
   dtcurve <- x$dtcurve
+  desat <- x$desat$desat_stop
   # set global plot ----
   delta_x <- diff(x$hour) * 0.1
   delta_y <- (depth(x) - min(dtcurve$depths)) * 0.2
@@ -178,11 +179,15 @@ plot.dive <- function(x,
   if(time_print){
     time_i <- times_inf(x, col = call_par$col)
     do.call(text, time_i)
-  } else if(deco_print){
-    for (i in x$desat$depth[x$desat$time > 0]) {
+  } 
+  if(deco_print){
+    for (i in desat$depth[desat$time > 0]) {
       text(
-        x = mean(dtcurve$time[dtcurve$depths == i]), y = -i,
-        paste(x$desat$time[x$desat$depth == i], "'", sep = ""), pos = 3,
+        x = mean(c(desat$hour[desat$depth == i], 
+                 desat$hour[desat$depth == i] + desat$time[desat$depth == i])) +
+          x$hour[1], 
+        y = -i,
+        labels = paste(desat$time[desat$depth == i], "'", sep = ""), pos = 3,
         col = call_par$col
       )
     }
@@ -391,6 +396,7 @@ plot.ndive <- function(x,
                 def_cols = def_cols, cut_inter = cut_inter, legend = legend,
                 add = add)
   
+  
   # SOLO plot only call plot.dive
   if (x$type == 'solo'){
     solo_par <- call_par
@@ -417,7 +423,7 @@ plot.ndive <- function(x,
               min(x$dive1$dtcurve$depths, x$dive2$dtcurve$depths) - delta_y)
   
   # TODO : why a duplicate here from line 457 ?
-  call_par <- list(...)
+  # call_par <- list(...)
   
   names_defaut_par <- names(default_par)
   for (i in seq_along(default_par)) {

--- a/R/graphic_utils.R
+++ b/R/graphic_utils.R
@@ -66,13 +66,7 @@ times_inf <- function(x, col = "black"){
   
   desat <- x$desat$desat_stop
   
-  times <- c(times, (desat$time + 2 *desat$hour ) /2 )
-  depths <- c(depths, desat$depth)
-  dtimes <- c(dtimes, desat$time)
-  
-  times <- times[!duplicated(dtimes)] + x$hour[1]
-  depths <- depths[!duplicated(dtimes)]
-  dtimes <- dtimes[!duplicated(dtimes)]
+  times <- times + x$hour[1]
   
   pos <- rep(3,length(dtimes))
   

--- a/R/methods_dive.R
+++ b/R/methods_dive.R
@@ -304,8 +304,10 @@ rm_secu <- function(dive){
         dtcurve$times <- replace(
           dtcurve$times, length(dtcurve$times),
           tail(dtcurve$times, 1) - 0.5 + 3/params["ascent_speed"])
+        
         desat$desat_stop[3,3] <- NA
-        desat$desat_stop <- type.convert(desat$desat_stop) # cause only NA 
+        desat$desat_stop <- type.convert(desat$desat_stop, as.is = NA) 
+        # cause only logical NA
         params["dtr"] <- params["dtr"] - 0.5 + 3/params["ascent_speed"]
         hour[2] <- hour[2] - 0.5 + 3/params["ascent_speed"]
         rownames(dtcurve) <- 1:nrow(dtcurve)

--- a/tests/testthat/test-graphic_utils.R
+++ b/tests/testthat/test-graphic_utils.R
@@ -43,10 +43,10 @@ test_that("depth_inf_output", {
 test_that("time_inf_output", {
   d <- dive(depth = c(0, 20, 19, 10, 7), 
             time = c(0, 2, 15, 20,  40)) 
-  exp <- data.frame(x = c(8.5, 17.5, 30.0, 41.9, NA), 
-                    y = c(-19.5, -14.5, -8.5, -3.0, -9.0),
-                    labels = c("13'", "5'", "20'", "3'", "0'"), 
-                    pos = rep(3, 5), col = rep("black", 5), 
+  exp <- data.frame(x = c(8.5, 17.5, 30.0, 41.9), 
+                    y = c(-19.5, -14.5, -8.5, -3.0),
+                    labels = c("13'", "5'", "20'", "3'"), 
+                    pos = rep(3, 4), col = rep("black", 4), 
                     stringsAsFactors = FALSE)
   expect_equal(times_inf(d), exp)
 })


### PR DESCRIPTION
Plot function was sometimes messing with time info.
This is caused by the times_inf() functions which add desat times
and remove duplicated ones. Then if desat time is the same as the
depth time, only one is shown.
Also options where either time_print or deco_print. Now both can be
added to the plot. If both are present, the text is bold but this is a
minor issue.

Plot check still require human check with the dev/graphic_vignette,
which is difficult and explain why all the graphic script is not tested.

Resolves: #16 